### PR TITLE
categories added and commonkeySize vs securityStrength

### DIFF
--- a/yaml/3des.yaml
+++ b/yaml/3des.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: 3des
 name: Triple Data Encryption Standard
 cryptoClass: Symmetric-Key-Algorithm/Block-Cipher

--- a/yaml/3way.yaml
+++ b/yaml/3way.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: 3way
 name: 3-Way Block Cipher
 cryptoClass: Symmetric-Key-Algorithm/Block-Cipher

--- a/yaml/ASN1.yaml
+++ b/yaml/ASN1.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: asn1
 name: Abstract Syntax Notation One
 cryptoClass: Symmetric-Key-Algorithm/Encoding

--- a/yaml/CMAC.yaml
+++ b/yaml/CMAC.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: CMAC
 name: Cipher-based Message Authentication Code
 cryptoClass: Cryptographic-Hash-Function/Message-Authentication-Code

--- a/yaml/X509.yaml
+++ b/yaml/X509.yaml
@@ -1,4 +1,5 @@
+# SPDX-License-Identifier: CC0-1.0
 id: X509
-name: ITU-T Recommendation X.509 – Public Key Infrastructure Certificate and Certificate Revocation List (CRL) Profile
+name: ITU-T Recommendation X.509 - Public Key Infrastructure Certificate Framework
 cryptoClass: Asymmetric-Key-Algorithm/Protocol
 commonkeySize: '128'

--- a/yaml/aes.yaml
+++ b/yaml/aes.yaml
@@ -1,5 +1,6 @@
+# SPDX-License-Identifier: CC0-1.0
 id: aes
 name: Advanced Encryption Standard
 cryptoClass: Symmetric-Key-Algorithm/Block-Cipher
 commonkeySize: '256'
-specifiedkeySize: '128'-'256'
+specifiedkeySize: '128'TO'256'

--- a/yaml/aria.yaml
+++ b/yaml/aria.yaml
@@ -1,5 +1,6 @@
+# SPDX-License-Identifier: CC0-1.0
 id: aria
 name: Aria Block Cipher
 cryptoClass: Symmetric-Key-Algorithm/Block-Cipher
 commonkeySize: '128'
-specifiedkeySize: '128'-'256'
+specifiedkeySize: '128'TO'256'

--- a/yaml/bcrypt.yaml
+++ b/yaml/bcrypt.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: bcrypt
 name: OpenBSD Blowfish password hashing scheme
 cryptoClass: Cryptographic-Hash-Function/Password-Hashing

--- a/yaml/blakex.yaml
+++ b/yaml/blakex.yaml
@@ -1,5 +1,6 @@
+# SPDX-License-Identifier: CC0-1.0
 id: blakex
 name: BLAKE Hash Function
 cryptoClass: Cryptographic-Hash-Function/Hash-Function
-commonkeySize: '256' AND '512'
-specifiedkeySize: '256'-'512'
+commonkeySize: '256'AND'512'
+specifiedkeySize: '256'TO'512'

--- a/yaml/blowfish.yaml
+++ b/yaml/blowfish.yaml
@@ -1,5 +1,6 @@
+# SPDX-License-Identifier: CC0-1.0
 id: blowfish
 name: Blowfish Cipher
 cryptoClass: Symmetric-Key-Algorithm/Block-Cipher
 commonkeySize: '320'
-specifiedkeySize: '128'-'448'
+specifiedkeySize: '128'TO'448'

--- a/yaml/blum-goldwasser.yaml
+++ b/yaml/blum-goldwasser.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: blum-goldwasser
 name: Blum-Goldwasser Probabilistic Encryption
 cryptoClass: Asymmetric-Key-Algorithm/Public-Key-Cipher

--- a/yaml/camellia.yaml
+++ b/yaml/camellia.yaml
@@ -1,5 +1,6 @@
+# SPDX-License-Identifier: CC0-1.0
 id: camellia
 name: Camellia Cipher
 cryptoClass: Symmetric-Key-Algorithm/Block-Cipher
 commonkeySize: '256'
-specifiedkeySize: '128'-'256'
+specifiedkeySize: '128'TO'256'

--- a/yaml/cast.yaml
+++ b/yaml/cast.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: cast
 name: Carlisle Adams and Stafford Tavares
 cryptoClass: Symmetric-Key-Algorithm/Block-Cipher

--- a/yaml/chacha(salsa).yaml
+++ b/yaml/chacha(salsa).yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: chacha(salsa)
 name: ChaCha Stream Cipher
 cryptoClass: Symmetric-Key-Algorithm/Stream-Cipher

--- a/yaml/cmea.yaml
+++ b/yaml/cmea.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: cmea
 name: Cellular Message Encryption Algorithm
 cryptoClass: Symmetric-Key-Algorithm/Stream-Cipher

--- a/yaml/cms.yaml
+++ b/yaml/cms.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: cms
 name: Cryptographic Message Syntax
 cryptoClass: Asymmetric-Key-Algorithm/Protocol

--- a/yaml/cobra.yaml
+++ b/yaml/cobra.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: cobra
 name: Cobra Cipher
 cryptoClass: Symmetric-Key-Algorithm/Block-Cipher

--- a/yaml/crc16.yaml
+++ b/yaml/crc16.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: crc16
 name:  Cyclic Redundancy Check 16-bit
 cryptoClass: Cryptographic-Hash-Function/Checksum

--- a/yaml/crc32.yaml
+++ b/yaml/crc32.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: crc32
 name:  Cyclic Redundancy Check 32-bit
 cryptoClass: Cryptographic-Hash-Function/Checksum

--- a/yaml/dcc.yaml
+++ b/yaml/dcc.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: dcc
 name:  Direct Code Construction
 cryptoClass: Cryptographic-Hash-Function/Hash-Function

--- a/yaml/des.yaml
+++ b/yaml/des.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: des
 name: Data Encryption Standard
 cryptoClass: Symmetric-Key-Algorithm/Block-Cipher

--- a/yaml/desede.yaml
+++ b/yaml/desede.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: desede
 name:
 cryptoClass: Symmetric-Key-Algorithm/Block-Cipher

--- a/yaml/dhe.yaml
+++ b/yaml/dhe.yaml
@@ -1,5 +1,6 @@
+# SPDX-License-Identifier: CC0-1.0
 id: dhe
 name: Diffie-Hellman Ephemeral
 cryptoClass: Asymmetric-Key-Algorithm/Key-Exchange
 commonkeySize: '128'
-specifiedkeySize: '2048'-'4096'
+specifiedkeySize: '2048'TO'4096'

--- a/yaml/dhies.yaml
+++ b/yaml/dhies.yaml
@@ -1,5 +1,6 @@
+# SPDX-License-Identifier: CC0-1.0
 id: dhies
 name: Diffie-Hellman Integrated Encryption Scheme
 cryptoClass: Asymmetric-Key-Algorithm/Hybrid-Cipher
 commonkeySize: '128'
-specifiedkeySize: '2048'-'4096'
+specifiedkeySize: '2048'TO'4096'

--- a/yaml/diffiehellman.yaml
+++ b/yaml/diffiehellman.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: diffiehellman
 name: Diffie-Hellman Key Exchange
 cryptoClass: Asymmetric-Key-Algorithm/Key-Exchange

--- a/yaml/dsa.yaml
+++ b/yaml/dsa.yaml
@@ -1,5 +1,6 @@
+# SPDX-License-Identifier: CC0-1.0
 id: dsa
 name: Digital Signature Algorithm
 cryptoClass: Asymmetric-Key-Algorithm/Digital-Signature
 commonkeySize: '128'
-specifiedkeySize: '2048'-'3072'
+specifiedkeySize: '2048'TO'3072'

--- a/yaml/ecdh.yaml
+++ b/yaml/ecdh.yaml
@@ -1,5 +1,6 @@
+# SPDX-License-Identifier: CC0-1.0
 id: ecdh
 name: Elliptic-Curve Diffie-Hellman
 cryptoClass: Asymmetric-Key-Algorithm/Key-Exchange
 commonkeySize: '128'
-specifiedkeySize: '256'-'521'
+specifiedkeySize: '256'TO'521'

--- a/yaml/ecmqv.yaml
+++ b/yaml/ecmqv.yaml
@@ -1,5 +1,6 @@
+# SPDX-License-Identifier: CC0-1.0
 id: ecmqv
 name: Elliptic Curve Menezes-Qu-Vanstone
 cryptoClass: Asymmetric-Key-Algorithm/Key-Exchange
 commonkeySize: '128'
-specifiedkeySize: '256'-'521'
+specifiedkeySize: '256'TO'521'

--- a/yaml/elgamal.yaml
+++ b/yaml/elgamal.yaml
@@ -1,5 +1,6 @@
+# SPDX-License-Identifier: CC0-1.0
 id: elgamal
 name: ElGamal Encryption System
 cryptoClass: Asymmetric-Key-Algorithm/Public-Key-Cipher
 commonkeySize: '128'
-specifiedkeySize: '2048'-'4096'
+specifiedkeySize: '2048'TO'4096'

--- a/yaml/f8.yaml
+++ b/yaml/f8.yaml
@@ -1,4 +1,5 @@
+# SPDX-License-Identifier: CC0-1.0
 id: f8
-name: F8 Mode of Operation
+name:
 cryptoClass: Symmetric-Key-Algorithm/Stream-Cipher
 commonkeySize: '128'

--- a/yaml/fasthash.yaml
+++ b/yaml/fasthash.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: fasthash
 name: FastHash Algorithm
 cryptoClass: Cryptographic-Hash-Function/Hash-Function

--- a/yaml/fcrypt.yaml
+++ b/yaml/fcrypt.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: fcrypt
 name: Fast DES
 cryptoClass: Symmetric-Key-Algorithm/Block-Cipher

--- a/yaml/feal.yaml
+++ b/yaml/feal.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: feal
 name: Fast Data Encipherment Algorithm
 cryptoClass: Symmetric-Key-Algorithm/Block-Cipher

--- a/yaml/fletcher.yaml
+++ b/yaml/fletcher.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: fletcher
 name: Fletcher's Checksum
 cryptoClass: Cryptographic-Hash-Function/Checksum

--- a/yaml/fnv1.yaml
+++ b/yaml/fnv1.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: fnv1
 name: Fowler-Noll-Vo Hash Function
 cryptoClass: Cryptographic-Hash-Function/Hash-Function

--- a/yaml/fortuna.yaml
+++ b/yaml/fortuna.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: fortuna
 name: Fortuna Random Number Generator
 cryptoClass: Symmetric-Key-Algorithm/Random-Number-Generator

--- a/yaml/gea0-x.yaml
+++ b/yaml/gea0-x.yaml
@@ -1,4 +1,5 @@
+# SPDX-License-Identifier: CC0-1.0
 id: gea0-x
 name: GPRS Encryption Algorithm version 0
 cryptoClass: Symmetric-Key-Algorithm/Stream-Cipher
-commonkeySize: 64-128
+commonkeySize: '64'TO'128'

--- a/yaml/gost.yaml
+++ b/yaml/gost.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: gost
 name: GOST Block Cipher
 cryptoClass: Symmetric-Key-Algorithm/Block-Cipher

--- a/yaml/grain.yaml
+++ b/yaml/grain.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: grain
 name: Grain Stream Cipher
 cryptoClass: Symmetric-Key-Algorithm/Stream-Cipher

--- a/yaml/haval.yaml
+++ b/yaml/haval.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: haval
 name: HAVAL Hash Function
 cryptoClass: Cryptographic-Hash-Function/Hash-Function

--- a/yaml/hc128.yaml
+++ b/yaml/hc128.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: hc128
 name: Hongjun Wu's Cipher 128
 cryptoClass: Symmetric-Key-Algorithm/Stream-Cipher

--- a/yaml/hc256.yaml
+++ b/yaml/hc256.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: hc256
 name:  Hongjun Wu's Cipher 256
 cryptoClass: Symmetric-Key-Algorithm/Stream-Cipher

--- a/yaml/ice.yaml
+++ b/yaml/ice.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: ice
 name: Information Concealment Engine
 cryptoClass: Symmetric-Key-Algorithm/Block-Cipher

--- a/yaml/idea.yaml
+++ b/yaml/idea.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: idea
 name: International Data Encryption Algorithm
 cryptoClass: Symmetric-Key-Algorithm/Block-Cipher

--- a/yaml/isaac.yaml
+++ b/yaml/isaac.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: isaac
 name: ISAAC Random Number Generator
 cryptoClass: Symmetric-Key-Algorithm/Random-Number-Generator

--- a/yaml/juniper.yaml
+++ b/yaml/juniper.yaml
@@ -1,4 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: juniper
-name: Juniper Cipher
+name: Juniper Ciphe
 cryptoClass: Symmetric-Key-Algorithm/Block-Cipher
-

--- a/yaml/kazumi.yaml
+++ b/yaml/kazumi.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: kazumi
 name:  Kazumi Cipher
 cryptoClass: Symmetric-Key-Algorithm/Block-Cipher

--- a/yaml/keccak.yaml
+++ b/yaml/keccak.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: keccak
 name: Keccak Hash Function
 cryptoClass: Cryptographic-Hash-Function/Hash-Function

--- a/yaml/khazad.yaml
+++ b/yaml/khazad.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: khazad
 name: Khazad Block Ciphe
 cryptoClass: Symmetric-Key-Algorithm/Block-Cipher

--- a/yaml/loki91.yaml
+++ b/yaml/loki91.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: loki91
 name: LOKY91 Bock Cipher
 cryptoClass: Symmetric-Key-Algorithm/Block-Cipher

--- a/yaml/luc.yaml
+++ b/yaml/luc.yaml
@@ -1,5 +1,6 @@
+# SPDX-License-Identifier: CC0-1.0
 id: luc
-name: LUCas-based public key cryptosystem
+name:
 cryptoClass: Asymmetric-Key-Algorithm/Public-Key-Cipher
 commonkeySize: '64'
 specifiedkeySize: '1024'

--- a/yaml/lucifer.yaml
+++ b/yaml/lucifer.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: lucifer
 name: Lucifer Cipher
 cryptoClass: Symmetric-Key-Algorithm/Block-Cipher

--- a/yaml/mceliece.yaml
+++ b/yaml/mceliece.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: mceliece
 name: McEliece Cryptosystem
 cryptoClass: Asymmetric-Key-Algorithm/Public-Key-Cipher

--- a/yaml/md160.yaml
+++ b/yaml/md160.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: md160
 name: RACE Integrity Primitives Evaluation Message Digest)
 cryptoClass: Cryptographic-Hash-Function/Hash-Function

--- a/yaml/md2.yaml
+++ b/yaml/md2.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: md2
 name: Message-Digest Algorithm 2
 cryptoClass: Cryptographic-Hash-Function/Hash-Function

--- a/yaml/md4.yaml
+++ b/yaml/md4.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: md4
 name: Message-Digest Algorithm 4
 cryptoClass: Cryptographic-Hash-Function/Hash-Function

--- a/yaml/md5.yaml
+++ b/yaml/md5.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: md5
 name: Message-Digest Algorithm 5
 cryptoClass: Cryptographic-Hash-Function/Hash-Function

--- a/yaml/md6.yaml
+++ b/yaml/md6.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: md6
 name: Message-Digest Algorithm 6
 cryptoClass: Cryptographic-Hash-Function/Hash-Function

--- a/yaml/mdc2.yaml
+++ b/yaml/mdc2.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: mdc2
 name: Modification Detection Code 2
 cryptoClass: Cryptographic-Hash-Function/Hash-Function

--- a/yaml/misty1.yaml
+++ b/yaml/misty1.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: misty1
 name: MISTY1 Block Cipher
 cryptoClass: Symmetric-Key-Algorithm/Block-Cipher

--- a/yaml/mqv.yaml
+++ b/yaml/mqv.yaml
@@ -1,5 +1,6 @@
+# SPDX-License-Identifier: CC0-1.0
 id: mqv
 name: Menezes-Qu-Vanstone
 cryptoClass: Asymmetric-Key-Algorithm/Key-Exchange
 commonkeySize: '512'
-specifiedkeySize: '2048'-'4096'
+specifiedkeySize: '2048'TO'4096'

--- a/yaml/mscash.yaml
+++ b/yaml/mscash.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: mscash
 name: MSCash2 Password Hashing
 cryptoClass: Cryptographic-Hash-Function/Password-Hashing

--- a/yaml/mscash2.yaml
+++ b/yaml/mscash2.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: mscash2
 name: MSCash2 Password Hashing
 cryptoClass: Cryptographic-Hash-Function/Password-Hashing

--- a/yaml/multi2.yaml
+++ b/yaml/multi2.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: multi2
 name: MULTI2 Cipher
 cryptoClass: Symmetric-Key-Algorithm/Block-Cipher

--- a/yaml/nimbus.yaml
+++ b/yaml/nimbus.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: nimbus
 name: Nimbus Cipher
 cryptoClass: Symmetric-Key-Algorithm/Block-Cipher

--- a/yaml/noekeon.yaml
+++ b/yaml/noekeon.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: noekeon
 name: NOEKEON Block Cipher
 cryptoClass: Symmetric-Key-Algorithm/Block-Cipher

--- a/yaml/ntruencrypt.yaml
+++ b/yaml/ntruencrypt.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: ntruencrypt
 name: N-th degree TRuncated polynomial Ring Units
 cryptoClass: Asymmetric-Key-Algorithm/Public-Key-Cipher

--- a/yaml/panama.yaml
+++ b/yaml/panama.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: panama
 name: PANAMA Hash and Stream Cipher
 cryptoClass: Symmetric-Key-Algorithm/Stream-Cipher

--- a/yaml/pbe.yaml
+++ b/yaml/pbe.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: pbe
 name: Password-Based Encryption
 cryptoClass: Symmetric-Key-Algorithm/Key-Derivation

--- a/yaml/pbes1.yaml
+++ b/yaml/pbes1.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: pbes1
 name: Password-Based Encryption Scheme 1
 cryptoClass: Symmetric-Key-Algorithm/Key-Derivation

--- a/yaml/pbes2.yaml
+++ b/yaml/pbes2.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: pbes2
 name: Password-Based Encryption Scheme 2
 cryptoClass: Symmetric-Key-Algorithm/Key-Derivation

--- a/yaml/pbkdf1.yaml
+++ b/yaml/pbkdf1.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: pbkdf1
 name: Password-Based Key Derivation Function 1
 cryptoClass: Cryptographic-Hash-Function/Key-Derivation

--- a/yaml/pbkdf2.yaml
+++ b/yaml/pbkdf2.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: pbkdf2
 name: Password-Based Key Derivation Function 2
 cryptoClass: Cryptographic-Hash-Function/Key-Derivation

--- a/yaml/pkcs12.yaml
+++ b/yaml/pkcs12.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: pkcs12
 name: Public Key Cryptography Standards 12
 cryptoClass: Asymmetric-Key-Algorithm/Protocol

--- a/yaml/pkcs7.yaml
+++ b/yaml/pkcs7.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: pkcs7
 name: Public Key Cryptography Standards 7
 cryptoClass: Asymmetric-Key-Algorithm/Protocol

--- a/yaml/quad.yaml
+++ b/yaml/quad.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: quad
 name:  Quad Cipher
 cryptoClass: Symmetric-Key-Algorithm/Stream-Cipher

--- a/yaml/rabbit.yaml
+++ b/yaml/rabbit.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: rabbit
 name: Rabbit Stream Cipher
 cryptoClass: Symmetric-Key-Algorithm/Stream-Cipher

--- a/yaml/rabin.yaml
+++ b/yaml/rabin.yaml
@@ -1,5 +1,6 @@
+# SPDX-License-Identifier: CC0-1.0
 id: rabin
 name: Rabin Encryption Algorithm
 cryptoClass: Asymmetric-Key-Algorithm/Public-Key-Cipher
 commonkeySize: '128'
-specifiedkeySize: '1024'-'2048'
+specifiedkeySize: '1024'TO'2048'

--- a/yaml/rc2.yaml
+++ b/yaml/rc2.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: rc2
 name:  Rivest Cipher 2
 cryptoClass: Symmetric-Key-Algorithm/Block-Cipher

--- a/yaml/rc4-hmac.yaml
+++ b/yaml/rc4-hmac.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: rc4-hmac
 name: RC4 with HMAC-MD5
 cryptoClass: Symmetric-Key-Algorithm/Stream-Cipher

--- a/yaml/rc4.yaml
+++ b/yaml/rc4.yaml
@@ -1,5 +1,6 @@
+# SPDX-License-Identifier: CC0-1.0
 id: rc4
 name: Rivest Cipher 4
 cryptoClass: Symmetric-Key-Algorithm/Stream-Cipher
 commonkeySize: '2048'
-specifiedkeySize: '128'-'2048'
+specifiedkeySize: '128'TO'2048'

--- a/yaml/rc5.yaml
+++ b/yaml/rc5.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: rc5
 name: Rivest Cipher 5
 cryptoClass: Symmetric-Key-Algorithm/Block-Cipher

--- a/yaml/rc6.yaml
+++ b/yaml/rc6.yaml
@@ -1,5 +1,6 @@
+# SPDX-License-Identifier: CC0-1.0
 id: rc6
 name: Rivest Cipher 6
 cryptoClass: Symmetric-Key-Algorithm/Block-Cipher
 commonkeySize: '128'
-specifiedkeySize: '128'-'256'
+specifiedkeySize: '128'TO'256'

--- a/yaml/rijndael.yaml
+++ b/yaml/rijndael.yaml
@@ -1,5 +1,6 @@
+# SPDX-License-Identifier: CC0-1.0
 id: rijndael
 name: Rijndael - AES Candidate Algorithm
 cryptoClass: Symmetric-Key-Algorithm/Block-Cipher
 commonkeySize: '256'
-specifiedkeySize: '128'-'256'
+specifiedkeySize: '128'TO'256'

--- a/yaml/ripemd.yaml
+++ b/yaml/ripemd.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: ripemd
 name: RIPEMD Hash Function
 cryptoClass: Cryptographic-Hash-Function/Hash-Function

--- a/yaml/rsa-oaep.yaml
+++ b/yaml/rsa-oaep.yaml
@@ -1,5 +1,6 @@
+# SPDX-License-Identifier: CC0-1.0
 id: rsa-oaep
 name: RSA with Optimal Asymmetric Encryption Padding
 cryptoClass: Asymmetric-Key-Algorithm/Public-Key-Cipher
 commonkeySize: '128'
-specifiedkeySize: '2048'-'4096'
+specifiedkeySize: '2048'TO'4096'

--- a/yaml/rsa.yaml
+++ b/yaml/rsa.yaml
@@ -1,5 +1,6 @@
+# SPDX-License-Identifier: CC0-1.0
 id: rsa
 name: Rivest–Shamir–Adleman Algorithm
 cryptoClass: Asymmetric-Key-Algorithm/Public-Key-Cipher
 commonkeySize: '128'
-specifiedkeySize: '2048'-'4096'
+specifiedkeySize: '2048'TO'4096'

--- a/yaml/salsa10.yaml
+++ b/yaml/salsa10.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: salsa10
 name: Salsa10 Stream Cipher
 cryptoClass: Symmetric-Key-Algorithm/Stream-Cipher

--- a/yaml/salsa20.yaml
+++ b/yaml/salsa20.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: salsa20
 name: Salsa20 Stream Cipher
 cryptoClass: Symmetric-Key-Algorithm/Stream-Cipher

--- a/yaml/sapphire.yaml
+++ b/yaml/sapphire.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: sapphire
 name: SAPPHIRE Cipher
 cryptoClass: Symmetric-Key-Algorithm/Stream-Cipher

--- a/yaml/seal.yaml
+++ b/yaml/seal.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: seal
 name: Software-Optimized Encryption Algorithm Cipher
 cryptoClass: Symmetric-Key-Algorithm/Stream-Cipher

--- a/yaml/seed.yaml
+++ b/yaml/seed.yaml
@@ -1,5 +1,6 @@
+# SPDX-License-Identifier: CC0-1.0
 id: seed
 name: SEED Block Cipher
 cryptoClass: Symmetric-Key-Algorithm/Block-Cipher
 commonkeySize: '256'
-specifiedkeySize: '128'-'256'
+specifiedkeySize: '128'TO'256'

--- a/yaml/serpent.yaml
+++ b/yaml/serpent.yaml
@@ -1,5 +1,6 @@
+# SPDX-License-Identifier: CC0-1.0
 id: serpent
 name: Serpent Block Cipher
 cryptoClass: Symmetric-Key-Algorithm/Block-Cipher
 commonkeySize: '128'
-specifiedkeySize: '128'-'256'
+specifiedkeySize: '128'TO'256'

--- a/yaml/shacal.yaml
+++ b/yaml/shacal.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: shacal
 name: SHACAL Block Cipher
 cryptoClass: Symmetric-Key-Algorithm/Block-Cipher

--- a/yaml/shark.yaml
+++ b/yaml/shark.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: shark
 name: SHARK Block Cipher
 cryptoClass: Symmetric-Key-Algorithm/Block-Cipher

--- a/yaml/shax.yaml
+++ b/yaml/shax.yaml
@@ -1,5 +1,6 @@
+# SPDX-License-Identifier: CC0-1.0
 id: shax
 name: SHA-x (SHA-1, SHA-256, etc.)
 cryptoClass: Cryptographic-Hash-Function/Hash-Function
-commonkeySize: 128-512
-specifiedkeySize: '224'-'512'
+commonkeySize: '128'AND'512
+specifiedkeySize: '224'TO'512'

--- a/yaml/shs.yaml
+++ b/yaml/shs.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: shs
 name:  Secure Hash Standard
 cryptoClass: Cryptographic-Hash-Function/Hash-Function

--- a/yaml/skein.yaml
+++ b/yaml/skein.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: skein
 name: Skein Hash Function
 cryptoClass: Cryptographic-Hash-Function/Hash-Function

--- a/yaml/skipjack.yaml
+++ b/yaml/skipjack.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: skipjack
 name: Skipjack Block Cipher
 cryptoClass: Symmetric-Key-Algorithm/Block-Cipher

--- a/yaml/sms4.yaml
+++ b/yaml/sms4.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: sms4
 name: SMS4 Block Cipher
 cryptoClass: Symmetric-Key-Algorithm/Block-Cipher

--- a/yaml/snerfu.yaml
+++ b/yaml/snerfu.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: snerfu
 name: SNERFU Hash Function
 cryptoClass: Cryptographic-Hash-Function/Hash-Function

--- a/yaml/snow.yaml
+++ b/yaml/snow.yaml
@@ -1,4 +1,5 @@
+# SPDX-License-Identifier: CC0-1.0
 id: snow
-name: Strong Nomenclature for Wireless
+name:
 cryptoClass: Symmetric-Key-Algorithm/Stream-Cipher
 commonkeySize: '128'

--- a/yaml/sober.yaml
+++ b/yaml/sober.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: sober
 name: SOBER Stream Cipher
 cryptoClass: Symmetric-Key-Algorithm/Stream-Cipher

--- a/yaml/sosemanuk.yaml
+++ b/yaml/sosemanuk.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: sosemanuk
 name: SOSEMANUK Stream Cipher
 cryptoClass: Symmetric-Key-Algorithm/Stream-Cipher

--- a/yaml/srp.yaml
+++ b/yaml/srp.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: srp
 name: Secure Remote Password Protocol
 cryptoClass: Asymmetric-Key-Algorithm/Protocol

--- a/yaml/ssha.yaml
+++ b/yaml/ssha.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: ssha
 name: Salted Secure Hash Algorithm
 cryptoClass: Cryptographic-Hash-Function/Hash-Function

--- a/yaml/tcrypt.yaml
+++ b/yaml/tcrypt.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: tcrypt
 name: TCRYPT Encryption
 cryptoClass: Symmetric-Key-Algorithm/Block-Cipher

--- a/yaml/tdes.yaml
+++ b/yaml/tdes.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: tdes
 name: Triple Data Encryption Standard
 cryptoClass: Symmetric-Key-Algorithm/Block-Cipher

--- a/yaml/tea.yaml
+++ b/yaml/tea.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: tea
 name: Tiny Encryption Algorithm
 cryptoClass: Symmetric-Key-Algorithm/Block-Cipher

--- a/yaml/threefish.yaml
+++ b/yaml/threefish.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: threefish
 name: Threefish Block Cipher
 cryptoClass: Symmetric-Key-Algorithm/Block-Cipher

--- a/yaml/tiger.yaml
+++ b/yaml/tiger.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: tiger
 name: Tiger Hash Function
 cryptoClass: Cryptographic-Hash-Function/Hash-Function

--- a/yaml/tnepres.yaml
+++ b/yaml/tnepres.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: tnepres
 name:  TNEPRES Block Cipher (Reverse Serpent)
 cryptoClass: Symmetric-Key-Algorithm/Block-Cipher

--- a/yaml/twofish.yaml
+++ b/yaml/twofish.yaml
@@ -1,5 +1,6 @@
+# SPDX-License-Identifier: CC0-1.0
 id: twofish
 name: Twofish Block Cipher
 cryptoClass: Symmetric-Key-Algorithm/Block-Cipher
 commonkeySize: '64'
-specifiedkeySize: '128'-'256'
+specifiedkeySize: '128'TO'256'

--- a/yaml/vmpc.yaml
+++ b/yaml/vmpc.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: vmpc
 name: VMPC Stream Cipher
 cryptoClass: Symmetric-Key-Algorithm/Stream-Cipher

--- a/yaml/wake.yaml
+++ b/yaml/wake.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: wake
 name: WAKE Stream Cipher
 cryptoClass: Symmetric-Key-Algorithm/Stream-Cipher

--- a/yaml/whirpool.yaml
+++ b/yaml/whirpool.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: whirpool
 name: Whirlpool Hash Function
 cryptoClass: Cryptographic-Hash-Function/Hash-Function

--- a/yaml/xtea.yaml
+++ b/yaml/xtea.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: xtea
 name: eXtended Tiny Encryption Algorithm
 cryptoClass: Symmetric-Key-Algorithm/Block-Cipher

--- a/yaml/xtr.yaml
+++ b/yaml/xtr.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: xtr
 name: XTR Public Key System
 cryptoClass: Asymmetric-Key-Algorithm/Public-Key-Cipher

--- a/yaml/yarrow.yaml
+++ b/yaml/yarrow.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: yarrow
 name: Yarrow Random Number Generator
 cryptoClass: Symmetric-Key-Algorithm/Random-Number-Generator

--- a/yaml/zipcrypt.yaml
+++ b/yaml/zipcrypt.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: zipcrypt
 name: ZipCrypt Encryption
 cryptoClass: Symmetric-Key-Algorithm/Block-Cipher

--- a/yaml/zuc.yaml
+++ b/yaml/zuc.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
 id: zuc
 name: ZUC Stream Cipher
 cryptoClass: Symmetric-Key-Algorithm/Stream-Cipher


### PR DESCRIPTION
- Added the category and the subcategory (classes, according to NIST) proposed by Quique, following NIST documentation #11 The attribute name is cryptoClass
- Added the new attribute name: keySize instead of securityStrength, as agreed on our meetings #10  

This PR represents the agreements taken during the meetings during the past month