### PR TITLE
Remove the AND operator for a yaml expression

### DIFF
--- a/yaml/blakex.yaml
+++ b/yaml/blakex.yaml
@@ -2,5 +2,5 @@
 id: blakex
 name: BLAKE Hash Function
 cryptoClass: Cryptographic-Hash-Function/Hash-Function
-commonkeySize: '256'AND'512'
+commonkeySize: {'256','512'}
 specifiedkeySize: '256'TO'512'

--- a/yaml/shax.yaml
+++ b/yaml/shax.yaml
@@ -2,5 +2,5 @@
 id: shax
 name: SHA-x (SHA-1, SHA-256, etc.)
 cryptoClass: Cryptographic-Hash-Function/Hash-Function
-commonkeySize: '128'AND'512
+commonkeySize: {'128','512'}
 specifiedkeySize: '224'TO'512'


### PR DESCRIPTION
The AND operator is substituted for the yaml way to express several values in two algorithms:
* blakex
* shax