### PR TITLE
yaml compatible expression instead of  operator TO

### DIFF
--- a/yaml/aes.yaml
+++ b/yaml/aes.yaml
@@ -3,4 +3,4 @@ id: aes
 name: Advanced Encryption Standard
 cryptoClass: Symmetric-Key-Algorithm/Block-Cipher
 commonkeySize: '256'
-specifiedkeySize: '128'TO'256'
+specifiedkeySize: {min: '128', max: '256'}

--- a/yaml/aria.yaml
+++ b/yaml/aria.yaml
@@ -3,4 +3,4 @@ id: aria
 name: Aria Block Cipher
 cryptoClass: Symmetric-Key-Algorithm/Block-Cipher
 commonkeySize: '128'
-specifiedkeySize: '128'TO'256'
+specifiedkeySize: {min: '128', max: '256'}

--- a/yaml/blakex.yaml
+++ b/yaml/blakex.yaml
@@ -2,5 +2,5 @@
 id: blakex
 name: BLAKE Hash Function
 cryptoClass: Cryptographic-Hash-Function/Hash-Function
-commonkeySize: '256'AND'512'
-specifiedkeySize: '256'TO'512'
+commonkeySize: {'256','512'}
+specifiedkeySize: {min: '256', max: '512'}

--- a/yaml/blowfish.yaml
+++ b/yaml/blowfish.yaml
@@ -3,4 +3,4 @@ id: blowfish
 name: Blowfish Cipher
 cryptoClass: Symmetric-Key-Algorithm/Block-Cipher
 commonkeySize: '320'
-specifiedkeySize: '128'TO'448'
+specifiedkeySize: {min: '128', max: '448'}

--- a/yaml/camellia.yaml
+++ b/yaml/camellia.yaml
@@ -3,4 +3,4 @@ id: camellia
 name: Camellia Cipher
 cryptoClass: Symmetric-Key-Algorithm/Block-Cipher
 commonkeySize: '256'
-specifiedkeySize: '128'TO'256'
+specifiedkeySize: {min: '128', max: '256'}

--- a/yaml/dhe.yaml
+++ b/yaml/dhe.yaml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: CC0-1.0
 id: dhe
 name: Diffie-Hellman Ephemeral
-cryptoClass: Asymmetric-Key-Algorithm/Key-Exchange
+cryptoClass: Asymmetric-Key-Algorithm/Key-Exchange-Mechanism
 commonkeySize: '128'
-specifiedkeySize: '2048'TO'4096'
+specifiedkeySize: {min: '2048', max: '4096'}

--- a/yaml/dhies.yaml
+++ b/yaml/dhies.yaml
@@ -3,4 +3,4 @@ id: dhies
 name: Diffie-Hellman Integrated Encryption Scheme
 cryptoClass: Asymmetric-Key-Algorithm/Hybrid-Cipher
 commonkeySize: '128'
-specifiedkeySize: '2048'TO'4096'
+specifiedkeySize: {min: '2048', max: '4096'}

--- a/yaml/dsa.yaml
+++ b/yaml/dsa.yaml
@@ -3,4 +3,4 @@ id: dsa
 name: Digital Signature Algorithm
 cryptoClass: Asymmetric-Key-Algorithm/Digital-Signature
 commonkeySize: '128'
-specifiedkeySize: '2048'TO'3072'
+specifiedkeySize: {min: '2048', max: '3072'}

--- a/yaml/ecdh.yaml
+++ b/yaml/ecdh.yaml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: CC0-1.0
 id: ecdh
 name: Elliptic-Curve Diffie-Hellman
-cryptoClass: Asymmetric-Key-Algorithm/Key-Exchange
+cryptoClass: Asymmetric-Key-Algorithm/Key-Exchange-Mechanism
 commonkeySize: '128'
-specifiedkeySize: '256'TO'521'
+specifiedkeySize: {min: '256', max: '521'}

--- a/yaml/ecmqv.yaml
+++ b/yaml/ecmqv.yaml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: CC0-1.0
 id: ecmqv
 name: Elliptic Curve Menezes-Qu-Vanstone
-cryptoClass: Asymmetric-Key-Algorithm/Key-Exchange
+cryptoClass: Asymmetric-Key-Algorithm/Key-Exchange-Mechanism
 commonkeySize: '128'
-specifiedkeySize: '256'TO'521'
+specifiedkeySize: {min: '256', max: '521'}

--- a/yaml/elgamal.yaml
+++ b/yaml/elgamal.yaml
@@ -3,4 +3,4 @@ id: elgamal
 name: ElGamal Encryption System
 cryptoClass: Asymmetric-Key-Algorithm/Public-Key-Cipher
 commonkeySize: '128'
-specifiedkeySize: '2048'TO'4096'
+specifiedkeySize: {min: '2048', max: '4096'}

--- a/yaml/gea0-x.yaml
+++ b/yaml/gea0-x.yaml
@@ -2,4 +2,4 @@
 id: gea0-x
 name: GPRS Encryption Algorithm version 0
 cryptoClass: Symmetric-Key-Algorithm/Stream-Cipher
-commonkeySize: '64'TO'128'
+commonkeySize: {min: '64', max: '128'}

--- a/yaml/mqv.yaml
+++ b/yaml/mqv.yaml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: CC0-1.0
 id: mqv
 name: Menezes-Qu-Vanstone
-cryptoClass: Asymmetric-Key-Algorithm/Key-Exchange
+cryptoClass: Asymmetric-Key-Algorithm/Key-Exchange-Mechanism
 commonkeySize: '512'
-specifiedkeySize: '2048'TO'4096'
+specifiedkeySize: {min: '2048', max: '4096'}

--- a/yaml/rabin.yaml
+++ b/yaml/rabin.yaml
@@ -3,4 +3,4 @@ id: rabin
 name: Rabin Encryption Algorithm
 cryptoClass: Asymmetric-Key-Algorithm/Public-Key-Cipher
 commonkeySize: '128'
-specifiedkeySize: '1024'TO'2048'
+specifiedkeySize: {min: '1024', max: '2048'}

--- a/yaml/rc4.yaml
+++ b/yaml/rc4.yaml
@@ -3,4 +3,4 @@ id: rc4
 name: Rivest Cipher 4
 cryptoClass: Symmetric-Key-Algorithm/Stream-Cipher
 commonkeySize: '2048'
-specifiedkeySize: '128'TO'2048'
+specifiedkeySize: {min: '128', max: '2048'}

--- a/yaml/rc6.yaml
+++ b/yaml/rc6.yaml
@@ -3,4 +3,4 @@ id: rc6
 name: Rivest Cipher 6
 cryptoClass: Symmetric-Key-Algorithm/Block-Cipher
 commonkeySize: '128'
-specifiedkeySize: '128'TO'256'
+specifiedkeySize: {min: '128', max: '256'}

--- a/yaml/rijndael.yaml
+++ b/yaml/rijndael.yaml
@@ -3,4 +3,4 @@ id: rijndael
 name: Rijndael - AES Candidate Algorithm
 cryptoClass: Symmetric-Key-Algorithm/Block-Cipher
 commonkeySize: '256'
-specifiedkeySize: '128'TO'256'
+specifiedkeySize: {min: '128', max: '256'}

--- a/yaml/rsa-oaep.yaml
+++ b/yaml/rsa-oaep.yaml
@@ -3,4 +3,4 @@ id: rsa-oaep
 name: RSA with Optimal Asymmetric Encryption Padding
 cryptoClass: Asymmetric-Key-Algorithm/Public-Key-Cipher
 commonkeySize: '128'
-specifiedkeySize: '2048'TO'4096'
+specifiedkeySize: {min: '2048', max: '4096'}

--- a/yaml/rsa.yaml
+++ b/yaml/rsa.yaml
@@ -3,4 +3,4 @@ id: rsa
 name: Rivest–Shamir–Adleman Algorithm
 cryptoClass: Asymmetric-Key-Algorithm/Public-Key-Cipher
 commonkeySize: '128'
-specifiedkeySize: '2048'TO'4096'
+specifiedkeySize: {min: '2048', max: '4096'}

--- a/yaml/seed.yaml
+++ b/yaml/seed.yaml
@@ -3,4 +3,4 @@ id: seed
 name: SEED Block Cipher
 cryptoClass: Symmetric-Key-Algorithm/Block-Cipher
 commonkeySize: '256'
-specifiedkeySize: '128'TO'256'
+specifiedkeySize: {min: '128', max: '256'}

--- a/yaml/serpent.yaml
+++ b/yaml/serpent.yaml
@@ -3,4 +3,4 @@ id: serpent
 name: Serpent Block Cipher
 cryptoClass: Symmetric-Key-Algorithm/Block-Cipher
 commonkeySize: '128'
-specifiedkeySize: '128'TO'256'
+specifiedkeySize: {min: '128', max: '256'}

--- a/yaml/shax.yaml
+++ b/yaml/shax.yaml
@@ -2,5 +2,5 @@
 id: shax
 name: SHA-x (SHA-1, SHA-256, etc.)
 cryptoClass: Cryptographic-Hash-Function/Hash-Function
-commonkeySize: '128'AND'512
-specifiedkeySize: '224'TO'512'
+commonkeySize: ['128','512']
+specifiedkeySize: {min: '224', max: '512'}

--- a/yaml/twofish.yaml
+++ b/yaml/twofish.yaml
@@ -3,4 +3,4 @@ id: twofish
 name: Twofish Block Cipher
 cryptoClass: Symmetric-Key-Algorithm/Block-Cipher
 commonkeySize: '64'
-specifiedkeySize: '128'TO'256'
+specifiedkeySize: {min: '128', max: '256'}


### PR DESCRIPTION
Algorithms with specifiedkeySize ranges converted:

aes - '128'TO'256' → {min: '128', max: '256'}
aria - '128'TO'256' → {min: '128', max: '256'}
blakex - '256'TO'512' → {min: '256', max: '512'}
blowfish - '128'TO'448' → {min: '128', max: '448'}
camellia - '128'TO'256' → {min: '128', max: '256'}
dhe - '2048'TO'4096' → {min: '2048', max: '4096'}
dhies - '2048'TO'4096' → {min: '2048', max: '4096'}
dsa - '2048'TO'3072' → {min: '2048', max: '3072'}
ecdh - '256'TO'521' → {min: '256', max: '521'}
ecmqv - '256'TO'521' → {min: '256', max: '521'}
elgamal - '2048'TO'4096' → {min: '2048', max: '4096'}
mqv - '2048'TO'4096' → {min: '2048', max: '4096'}
rabin - '1024'TO'2048' → {min: '1024', max: '2048'}
rc4 - '128'TO'2048' → {min: '128', max: '2048'}
rc6 - '128'TO'256' → {min: '128', max: '256'}
rijndael - '128'TO'256' → {min: '128', max: '256'}
rsa-oaep - '2048'TO'4096' → {min: '2048', max: '4096'}
rsa - '2048'TO'4096' → {min: '2048', max: '4096'}
seed - '128'TO'256' → {min: '128', max: '256'}
serpent - '128'TO'256' → {min: '128', max: '256'}
shax - '224'TO'512' → {min: '224', max: '512'}
twofish - '128'TO'256' → {min: '128', max: '256'}

Algorithm with commonkeySize range converted:

gea0-x - '64'TO'128' → {min: '64', max: '128'}