### PR TITLE
New algorithms definitions - Part 1

### DIFF
--- a/yaml/adler32.yaml
+++ b/yaml/adler32.yaml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: CC0-1.0
+id: 'adler32'
+name: 'Adler-32'
+cryptoClass: 'Cryptographic-Hash-Function/Hash-Function'
+commonkeySize: '32'
+specifiedkeySize: '32'

--- a/yaml/ansix931.yaml
+++ b/yaml/ansix931.yaml
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
+id: 'ansix931'
+name: 'ANSI X9.31'
+cryptoClass: 'Protocol-Standard'

--- a/yaml/ansix942.yaml
+++ b/yaml/ansix942.yaml
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
+id: 'ansix942'
+name: 'ANSI X9.42'
+cryptoClass: 'Protocol-Standard'

--- a/yaml/ansix963.yaml
+++ b/yaml/ansix963.yaml
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
+id: 'ansix963'
+name: 'ANSI X9.63'
+cryptoClass: 'Protocol-Standard'

--- a/yaml/argon2.yaml
+++ b/yaml/argon2.yaml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: CC0-1.0
+id: 'argon2'
+name: 'Argon2'
+cryptoClass: 'Key-Derivation-Function'
+commonkeySize: '256'
+specifiedkeySize: {min: '128', max: '512'}

--- a/yaml/blake2.yaml
+++ b/yaml/blake2.yaml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: CC0-1.0
+id: 'blake2'
+name: 'BLAKE2'
+cryptoClass: 'Cryptographic-Hash-Function/Hash-Function'
+commonkeySize: '512'
+specifiedkeySize: '512'

--- a/yaml/blake3.yaml
+++ b/yaml/blake3.yaml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: CC0-1.0
+id: 'blake3'
+name: 'BLAKE3'
+cryptoClass: 'Cryptographic-Hash-Function/Hash-Function'
+commonkeySize: '256'
+specifiedkeySize: '256'

--- a/yaml/cbc.yaml
+++ b/yaml/cbc.yaml
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
+id: 'cbc'
+name: 'Cipher Block Chaining'
+cryptoClass: 'Block-Cipher-Mode'

--- a/yaml/ccm.yaml
+++ b/yaml/ccm.yaml
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
+id: 'ccm'
+name: 'Counter with CBC-MAC'
+cryptoClass: 'Block-Cipher-Mode'

--- a/yaml/cfb.yaml
+++ b/yaml/cfb.yaml
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
+id: 'cfb'
+name: 'Cipher Feedback'
+cryptoClass: 'Block-Cipher-Mode'


### PR DESCRIPTION
# Added New algorithms to the list:

- ANSI X9.31 - Protocol-Standard
- ANSI X9.42 - Protocol-Standard
- ANSI X9.63 - Protocol-Standard
- Argon2 - Key-Derivation-Function
- BLAKE2 - Cryptographic-Hash-Function/Hash-Function
- BLAKE3 - Cryptographic-Hash-Function/Hash-Function
- Adler-32 - Cryptographic-Hash-Function/Hash-Function
- Cipher Block Chaining - Block-Cipher-Mode
- Cipher Feedback - Block-Cipher-Mode

For the proposed algorithms, using range notation was not needed.
 