### PR TITLE
typo in whirlpool.yaml and the algorithm ID

### DIFF
--- a/yaml/whirlpool.yaml
+++ b/yaml/whirlpool.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: CC0-1.0
-id: whirpool
+id: whirlpool
 name: Whirlpool Hash Function
 cryptoClass: Cryptographic-Hash-Function/Hash-Function
 commonkeySize: '128'


### PR DESCRIPTION
Corrections to Whirlpool 
* .yaml file name
* ID name

There was a typo. This PR closes ticket #40